### PR TITLE
Add grouping option for keys index

### DIFF
--- a/src/main/settings-service.ts
+++ b/src/main/settings-service.ts
@@ -2,7 +2,8 @@ import settings from 'electron-settings'
 
 export const SETTINGS = {
   VISUAL_EDITOR: { key: 'settings:visual-list-editor', label: 'Wizualny edytor list', settingType: Boolean },
-  LINE_NUMBERS: { key: 'settings:with-line-numbers', label: 'Numery linii w edytorze kodu', settingType: Boolean }
+  LINE_NUMBERS: { key: 'settings:with-line-numbers', label: 'Numery linii w edytorze kodu', settingType: Boolean },
+  GROUP_KEYS: { key: 'settings:group-keys', label: 'Grupowanie kluczy w indeksie', settingType: Boolean }
 }
 
 export default class SettingsService {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,12 +21,14 @@ export interface CfgApi {
 
   onVisualListChange(callback: (value: boolean) => void): () => void
   onWithLinesChange(callback: (value: boolean) => void): () => void
+  onGroupKeysChange(callback: (value: boolean) => void): () => void
 
   getTheme(): Promise<{ theme: string; isDark: boolean }>
   getHljsTheme(): Promise<{ theme: string }>
 
   getVisualListEdit(): Promise<{ settings: boolean }>
   getWithLines(): Promise<boolean>
+  getGroupKeys(): Promise<boolean>
 
   getRecent(): Promise<string[]>
 
@@ -91,6 +93,8 @@ const api: CfgApi = {
   getVisualListEdit: () => ipcRenderer.invoke('setting', SETTINGS.VISUAL_EDITOR.key),
   onWithLinesChange: (callback) => wrap(SETTINGS.LINE_NUMBERS.key, callback),
   getWithLines: () => ipcRenderer.invoke('setting', SETTINGS.LINE_NUMBERS.key),
+  onGroupKeysChange: (callback) => wrap(SETTINGS.GROUP_KEYS.key, callback),
+  getGroupKeys: () => ipcRenderer.invoke('setting', SETTINGS.GROUP_KEYS.key),
   getTheme: () => ipcRenderer.invoke('theme'),
   getHljsTheme: () => ipcRenderer.invoke('hljs-theme'),
   getRecent: () => ipcRenderer.invoke('app:recentDocuments'),

--- a/src/renderer/src/Index.tsx
+++ b/src/renderer/src/Index.tsx
@@ -1,4 +1,4 @@
-import { JSX, SetStateAction, useCallback, useEffect, useState } from 'react'
+import { JSX, SetStateAction, useCallback, useEffect, useLayoutEffect, useState } from 'react'
 import { Form } from 'react-bootstrap'
 import { ConfigResponse } from '../../shared/Config'
 import * as React from 'react'
@@ -7,6 +7,7 @@ import { XLg } from 'react-bootstrap-icons'
 export default function Index({ config }: { config: ConfigResponse }): JSX.Element {
   const [keys, setKeys] = useState([] as string[])
   const [filter, setFilter] = useState('')
+  const [groupKeys, setGroupKeys] = useState(false)
 
   useEffect(() => {
     setKeys(
@@ -16,6 +17,11 @@ export default function Index({ config }: { config: ConfigResponse }): JSX.Eleme
           return a.toLowerCase().localeCompare(b.toLowerCase())
         })
     )
+  }, [])
+
+  useLayoutEffect(() => {
+    window.api.getGroupKeys().then((value) => setGroupKeys(value))
+    return window.api.onGroupKeysChange((value) => setGroupKeys(value))
   }, [])
 
   const onFilterChange = useCallback(
@@ -37,6 +43,70 @@ export default function Index({ config }: { config: ConfigResponse }): JSX.Eleme
     return <></>
   }
 
+  interface Node {
+    name: string
+    path: string
+    key?: string
+    children: Map<string, Node>
+  }
+
+  function buildTree(list: string[]): Node[] {
+    const root = new Map<string, Node>()
+    list.forEach((key) => {
+      const parts = key.split('.')
+      let current = root
+      let path = ''
+      let node: Node
+      parts.forEach((part, index) => {
+        path = path ? `${path}.${part}` : part
+        if (!current.has(part)) {
+          current.set(part, { name: part, path, children: new Map() })
+        }
+        node = current.get(part)!
+        if (index === parts.length - 1) {
+          node.key = key
+        }
+        current = node.children
+      })
+    })
+    return Array.from(root.values())
+  }
+
+  const highlight = (value: string): JSX.Element[] | string =>
+    filter == ''
+      ? value
+      : value.split(new RegExp(`(${filter})`, 'gi')).map((part, index) => (
+          <span key={index} className={part.toLowerCase() === filter.toLowerCase() ? 'text-body-emphasis' : ''}>
+            {part}
+          </span>
+        ))
+
+  const renderNodes = (nodes: Node[]): JSX.Element[] => {
+    return nodes.map((node) => (
+      <li key={node.path}>
+        {node.key ? (
+          <a
+            className={'text-decoration-none'}
+            role={'button'}
+            onClick={() => {
+              const element = document.body.querySelector(`[data-schemapath="${node.key}"]`)
+              element?.scrollIntoView()
+              //@ts-ignore can call focus safely
+              element?.querySelector('input, select')?.focus()
+            }}
+          >
+            {highlight(node.name)}
+          </a>
+        ) : (
+          <span>{highlight(node.name)}</span>
+        )}
+        {node.children.size > 0 && <ul>{renderNodes(Array.from(node.children.values()))}</ul>}
+      </li>
+    ))
+  }
+
+  const filteredKeys = keys.filter((el) => filter === '' || el.toLowerCase().includes(filter.toLowerCase()))
+
   return (
     <>
       <Form.Group className={'mb-2 d-flex align-items-center position-relative'}>
@@ -54,10 +124,11 @@ export default function Index({ config }: { config: ConfigResponse }): JSX.Eleme
           </span>
         )}
       </Form.Group>
-      <ul className={'keys-index'}>
-        {keys
-          .filter((el) => filter === '' || el.toLowerCase().match(filter.toLowerCase()))
-          .map((key) => (
+      {groupKeys ? (
+        <ul className={'keys-index'}>{renderNodes(buildTree(filteredKeys))}</ul>
+      ) : (
+        <ul className={'keys-index'}>
+          {filteredKeys.map((key) => (
             <li key={key}>
               <a
                 className={'text-decoration-none'}
@@ -69,17 +140,12 @@ export default function Index({ config }: { config: ConfigResponse }): JSX.Eleme
                   element?.querySelector('input, select')?.focus()
                 }}
               >
-                {filter == ''
-                  ? key
-                  : key.split(new RegExp(`(${filter})`, 'g')).map((part, index) => (
-                      <span key={index} className={part === filter ? 'text-body-emphasis' : ''}>
-                        {part}
-                      </span>
-                    ))}
+                {highlight(key)}
               </a>
             </li>
           ))}
-      </ul>
+        </ul>
+      )}
     </>
   )
 }

--- a/src/renderer/src/assets/style.scss
+++ b/src/renderer/src/assets/style.scss
@@ -57,6 +57,11 @@ html, body, #root {
   margin: 0;
   font-size: 0.85em;
 }
+.keys-index ul {
+  list-style-type: none;
+  padding-left: 1rem;
+  margin: 0;
+}
 
 textarea {
   overflow: hidden;


### PR DESCRIPTION
## Summary
- add `GROUP_KEYS` setting
- expose API helpers for new setting
- add nested rendering for grouped keys
- style nested lists

## Testing
- `npm run lint` *(fails: Configuration for rule "prettier/prettier" is invalid)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_686457d4a23c832aa5d5c952c0b3f5a7