### PR TITLE
Add hex color editor

### DIFF
--- a/src/renderer/src/editor/Components.ts
+++ b/src/renderer/src/editor/Components.ts
@@ -7,13 +7,13 @@ import { FileInput } from './components/FileInput'
 import { DefaultInput } from './components/DefaultInput'
 import { CheckBoxInput } from './components/CheckBoxInput'
 import { TextAreaInput } from './components/TextAreaInput'
+import { HexColorInput } from './components/HexColorInput'
 
 import keyModifiers from '../../../shared/mudlet_key_modifiers.json'
 import { KeyInput } from './components/KeyInput'
 import { PasswordInput } from './components/PasswordInput'
 import { VisualListInput } from './components/VisualListInput'
 import { Settings } from '../Editor'
-
 
 export interface InputProperties {
   name: string
@@ -24,7 +24,11 @@ export interface InputProperties {
   setValidationErrors?: (error?: string) => void
 }
 
-export function controller(fieldType: FieldType, settings: Settings, contentType?: ContentType): (arg: InputProperties) => JSX.Element {
+export function controller(
+  fieldType: FieldType,
+  settings: Settings,
+  contentType?: ContentType
+): (arg: InputProperties) => JSX.Element {
   switch (fieldType) {
     case 'boolean':
       return BooleanSelect
@@ -34,6 +38,8 @@ export function controller(fieldType: FieldType, settings: Settings, contentType
       switch (contentType) {
         case 'mudlet_color':
           return ColorSelect
+        case 'hex_color':
+          return HexColorInput
         case 'file_path':
           return FileInput
         case 'keybind':

--- a/src/renderer/src/editor/components/HexColorInput.tsx
+++ b/src/renderer/src/editor/components/HexColorInput.tsx
@@ -1,0 +1,10 @@
+import { FormControl } from 'react-bootstrap'
+import { JSX } from 'react'
+import { InputProperties } from '../Components'
+
+export function HexColorInput({ name, value, updateCallback }: InputProperties): JSX.Element {
+  const current = typeof value === 'string' ? (value.startsWith('#') ? value : `#${value}`) : '#000000'
+  return (
+    <FormControl type={'color'} name={name} value={current} onChange={(e) => updateCallback(e.currentTarget.value)} />
+  )
+}

--- a/src/shared/Config.ts
+++ b/src/shared/Config.ts
@@ -8,7 +8,7 @@ export interface ConfigResponse {
 }
 
 export type FieldType = 'string' | 'boolean' | 'list' | 'map' | 'number'
-export type ContentType = 'mudlet_color' | 'key_modifiers' | 'file_path' | 'password' | 'keybind'
+export type ContentType = 'mudlet_color' | 'key_modifiers' | 'file_path' | 'password' | 'keybind' | 'hex_color'
 
 export interface FieldDefinition {
   name: string


### PR DESCRIPTION
## Summary
- support `hex_color` string content type in shared config schema
- handle `hex_color` fields with new color picker component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Configuration for rule "prettier/prettier" is invalid)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68948cc6b6d4832a9a5798246b7240a6